### PR TITLE
Non system ns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,6 @@ Session.vim
 *.out
 *.log
 template.yaml
+*.tgz
 
 .history

--- a/.helmignore
+++ b/.helmignore
@@ -24,3 +24,4 @@
 
 # Personal things
 template.yaml
+*.tgz

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: volcano
-version: 0.2.0-non-system-ns
+version: 0.2.0-devel
 # Note that Volcano uses a "v" before version numbers
 appVersion: v1.5.1
 type: application

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: volcano
-version: 0.2.0-devel
+version: 0.2.0-non-system-ns
 # Note that Volcano uses a "v" before version numbers
 appVersion: v1.5.1
 type: application

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: volcano
-version: 0.2.0
+version: 0.2.0-devel
 # Note that Volcano uses a "v" before version numbers
 appVersion: v1.5.1
 type: application

--- a/templates/admission/clusterrolebinding.yaml
+++ b/templates/admission/clusterrolebinding.yaml
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "volcano.name" . }}-admission
-  namespace: {{ .Release.Namespace }}-system
+  namespace: {{ .Release.Namespace }}

--- a/templates/admission/configmap.yaml
+++ b/templates/admission/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "volcano.name" . }}-admission
-  namespace: {{ .Release.Namespace }}-system
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "volcano.labels" . | indent 4 }}
 data:

--- a/templates/admission/deployment.yaml
+++ b/templates/admission/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "volcano.name" . }}-admission
-  namespace: {{ .Release.Namespace }}-system
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: admission
     {{- include "volcano.labels" . | indent 4 }}
@@ -24,15 +24,15 @@ spec:
         - --tls-private-key-file=/admission.local.config/certificates/tls.key
         - --ca-cert-file=/admission.local.config/certificates/ca.crt
         - --admission-conf=/admission.local.config/configmap/volcano-admission.conf
-        - --webhook-namespace={{ .Release.Namespace }}-system
+        - --webhook-namespace={{ .Release.Namespace }}
         - --webhook-service-name={{ include "volcano.name" . }}-admission
         {{- with .Values.webhookManager }}
         {{- if .ignoredNamespaces }}
-        # - --ignored-namespaces={{ $.Release.Namespace }},{{ $.Release.Namespace }}-system,{{- join "," .ignoredNamespaces }}
+        # - --ignored-namespaces={{ $.Release.Namespace }},{{- join "," .ignoredNamespaces }}
         {{- else if .managedNamespaces }}
         # - --managed-namespaces={{- join "," .managedNamespaces }}
         {{- else }}
-        # - --ignored-namespaces={{ $.Release.Namespace }},{{ $.Release.Namespace }}-system
+        # - --ignored-namespaces={{ $.Release.Namespace }}
         {{- end }}
         {{- end }}
         - --logtostderr

--- a/templates/admission/init-job.yaml
+++ b/templates/admission/init-job.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "volcano.name" . }}-admission-init
-  namespace: {{ .Release.Namespace }}-system
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: admission-init
     {{- include "volcano.labels" . | indent 4 }}
@@ -16,7 +16,7 @@ spec:
         - --service
         - {{ include "volcano.name" . }}-admission
         - --namespace
-        - {{ .Release.Namespace }}-system
+        - {{ .Release.Namespace }}
         - --secret
         - {{ include "volcano.name" . }}-admission
         {{- with .Values.webhookManager.image }}

--- a/templates/admission/service.yaml
+++ b/templates/admission/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "volcano.name" . }}-admission
-  namespace: {{ .Release.Namespace }}-system
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: admission-init
     {{- include "volcano.labels" . | indent 4 }}

--- a/templates/admission/serviceaccount.yaml
+++ b/templates/admission/serviceaccount.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "volcano.name" . }}-admission
-  namespace: {{ .Release.Namespace }}-system
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "volcano.labels" . | indent 4 }}

--- a/templates/controllers/clusterrolebinding.yaml
+++ b/templates/controllers/clusterrolebinding.yaml
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "volcano.name" . }}-controllers
-  namespace: {{ .Release.Namespace }}-system
+  namespace: {{ .Release.Namespace }}

--- a/templates/controllers/deployment.yaml
+++ b/templates/controllers/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "volcano.name" . }}-controllers
-  namespace: {{ .Release.Namespace }}-system
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: controller
     {{- include "volcano.labels" . | indent 4 }}

--- a/templates/controllers/serviceaccount.yaml
+++ b/templates/controllers/serviceaccount.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "volcano.name" . }}-controllers
-  namespace: {{ .Release.Namespace }}-system
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "volcano.labels" . | indent 4 }}

--- a/templates/scheduler/clusterrolebinding.yaml
+++ b/templates/scheduler/clusterrolebinding.yaml
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "volcano.name" . }}-scheduler
-  namespace: {{ .Release.Namespace }}-system
+  namespace: {{ .Release.Namespace }}

--- a/templates/scheduler/configmap.yaml
+++ b/templates/scheduler/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "volcano.name" . }}-scheduler
-  namespace: {{ .Release.Namespace }}-system
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "volcano.labels" . | indent 4 }}
 data:

--- a/templates/scheduler/deployment.yaml
+++ b/templates/scheduler/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "volcano.name" . }}-scheduler
-  namespace: {{ .Release.Namespace }}-system
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: scheduler
     {{- include "volcano.labels" . | indent 4 }}

--- a/templates/scheduler/service.yaml
+++ b/templates/scheduler/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "volcano.name" . }}-scheduler
-  namespace: {{ .Release.Namespace }}-system
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: admission-init
     {{- include "volcano.labels" . | indent 4 }}

--- a/templates/scheduler/serviceaccount.yaml
+++ b/templates/scheduler/serviceaccount.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "volcano.name" . }}-scheduler
-  namespace: {{ .Release.Namespace }}-system
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "volcano.labels" . | indent 4 }}

--- a/templates/system-namespace.yaml
+++ b/templates/system-namespace.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Release.Namespace }}-system
-  labels:
-    {{- include "volcano.labels" . | indent 4 }}


### PR DESCRIPTION
This just cleans up how resources get deployed. Previous versions used the namespace provided to `helm install --namespace <namespace>` to create a namespace where VCJobs would be expected to run, then put the Volocano resources themselves into a namespace called `<namespace>-system`. So, if Volcano were deployed using `helm install --namespace mynamespace`, it would create two namespaces: `mynamespace` and `mynamespace-system`.

I've found that this separation is not actually needed. So, instead, `helm install --namespace mynamespace` will now deploy everything into `mynamespace`.